### PR TITLE
Update to 2020-04-10

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "skip-icons-check": true
+}

--- a/org.freedesktop.Sdk.Extension.rust-nightly.yml
+++ b/org.freedesktop.Sdk.Extension.rust-nightly.yml
@@ -21,18 +21,18 @@ modules:
       - type: archive
         only-arches:
           - arm
-        url: https://static.rust-lang.org/dist/2019-11-10/rust-nightly-arm-unknown-linux-gnueabihf.tar.gz
-        sha256: bee6c8d953adc97c6517b0dd76b16423e5f99cd1e85958e045ec8281dc777b8c
+        url: https://static.rust-lang.org/dist/2020-04-10/rust-nightly-arm-unknown-linux-gnueabihf.tar.gz
+        sha256: 739fa446bce88dd3a65cf858f24f535caf723d6525f2a323d017d81f859bf0f5
       - type: archive
         only-arches:
           - aarch64
-        url: https://static.rust-lang.org/dist/2019-11-10/rust-nightly-aarch64-unknown-linux-gnu.tar.gz
-        sha256: 0a7ec76477383db84d52346c38dc9fda0da935654f965b5e1c8278d224eb8ed1
+        url: https://static.rust-lang.org/dist/2020-04-10/rust-nightly-aarch64-unknown-linux-gnu.tar.gz
+        sha256: ea2465878df02729103fa6dcc04fe59037af96d0a795e4450863982ca6107b0c
       - type: archive
         only-arches:
           - x86_64
-        url: https://static.rust-lang.org/dist/2019-11-10/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
-        sha256: cd5258c1e1d17fe076ee20e840049a34f89a49e39b82d3a31bf6f23dfa71602e
+        url: https://static.rust-lang.org/dist/2020-04-10/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
+        sha256: dd167a8a21b9eb065a94238b8edd262cc274f44b0ad868541c6c6c6542ca800d
     build-commands:
       - "./install.sh --prefix=/usr/lib/sdk/rust-nightly --disable-ldconfig --verbose"
   - name: scripts


### PR DESCRIPTION
Please update to 2020-04-10. This version should safe to update:
![DeepinScreenshot_select-area_20200412124933](https://user-images.githubusercontent.com/5614476/79065844-1ff3f900-7cbc-11ea-8f6c-ca42d54f431b.png)
