### PR TITLE
Update runtime to 20.08

### DIFF
--- a/org.freedesktop.Sdk.Extension.rust-nightly.yml
+++ b/org.freedesktop.Sdk.Extension.rust-nightly.yml
@@ -1,9 +1,9 @@
 id: org.freedesktop.Sdk.Extension.rust-nightly
-branch: "19.08"
+branch: "20.08"
 runtime: org.freedesktop.Sdk
 build-extension: true
 sdk: org.freedesktop.Sdk
-runtime-version: "19.08"
+runtime-version: "20.08"
 sdk-extensions: []
 separate-locales: false
 appstream-compose: false


### PR DESCRIPTION
Not sure should we create new branch or can simply move to latest and greatest FD runtime for Rust-nightly.

Fix: #7 