### PR TITLE
Update to 2020-12-09

### DIFF
--- a/org.freedesktop.Sdk.Extension.rust-nightly.yml
+++ b/org.freedesktop.Sdk.Extension.rust-nightly.yml
@@ -21,18 +21,18 @@ modules:
       - type: archive
         only-arches:
           - arm
-        url: https://static.rust-lang.org/dist/2020-08-15/rust-nightly-arm-unknown-linux-gnueabihf.tar.gz
-        sha256: 6338867a41d95d716d0297ad091db893b00feb03adaa1c0993133236f91d685c
+        url: https://static.rust-lang.org/dist/2020-12-09/rust-nightly-arm-unknown-linux-gnueabihf.tar.gz
+        sha256: 7d926a51d62fde00f6ce39a0cb9fb1ff9fb3c5c7b8a3c148d39216af0ae79e6a
       - type: archive
         only-arches:
           - aarch64
-        url: https://static.rust-lang.org/dist/2020-08-15/rust-nightly-aarch64-unknown-linux-gnu.tar.gz
-        sha256: a5ca0a558824fc75622289615616f67fcaf640edd7ce67f302ae9320a604431e
+        url: https://static.rust-lang.org/dist/2020-12-09/rust-nightly-aarch64-unknown-linux-gnu.tar.gz
+        sha256: 66de53a8db46e8d38f21105644fcbc6722e3967dc2bb3cb60fd025cf6e594f05
       - type: archive
         only-arches:
           - x86_64
-        url: https://static.rust-lang.org/dist/2020-08-15/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
-        sha256: 24b4681187654778817652273a68a4d55f5090604cd14b1f1c3ff8785ad24b99
+        url: https://static.rust-lang.org/dist/2020-12-09/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
+        sha256: d3a98701bd89564d8294791872d109470a5b44a48107d107c8f22055620bc0c2
     build-commands:
       - "./install.sh --prefix=/usr/lib/sdk/rust-nightly --disable-ldconfig --verbose"
   - name: scripts


### PR DESCRIPTION
Time to update and sync with [Veloren rust-toolchain](https://gitlab.com/veloren/veloren/-/blob/master/rust-toolchain) due to [build failure](https://flathub.org/builds/#/builders/19/builds/4118).