### PR TITLE
Allow to use mold with gcc

### DIFF
--- a/org.freedesktop.Sdk.Extension.rust-nightly.yml
+++ b/org.freedesktop.Sdk.Extension.rust-nightly.yml
@@ -31,6 +31,7 @@ modules:
           --verbose
 
       - install -Dm0755 mold/bin/mold ${SDK_PREFIX}/bin/mold
+      - install -Dm0755 mold/bin/ld.mold ${SDK_PREFIX}/bin/ld.mold
 
       - |
         gunzip rust-analyzer.gz


### PR DESCRIPTION
gcc needs the `ld.mold` symlink to be able to find mold, so we copy it in the extension too.

See https://github.com/flathub/org.freedesktop.Sdk.Extension.rust-stable/pull/462 for the PR that fixed it in for the rust-stable extension.